### PR TITLE
Make oldFields mapping hardcoded to speed up system

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Product.php
+++ b/app/code/core/Mage/Catalog/Model/Product.php
@@ -119,18 +119,6 @@ class Mage_Catalog_Model_Product extends Mage_Catalog_Model_Abstract
     }
 
     /**
-     * Init mapping array of short fields to
-     * its full names
-     *
-     * @return Varien_Object
-     */
-    protected function _initOldFieldsMap()
-    {
-        $this->_oldFieldsMap = Mage::helper('catalog')->getOldFieldMap();
-        return $this;
-    }
-
-    /**
      * Retrieve Store Id
      *
      * @return int

--- a/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/core/Mage/CatalogInventory/Model/Stock/Item.php
@@ -152,6 +152,7 @@ class Mage_CatalogInventory_Model_Stock_Item extends Mage_Core_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
+        // pre 1.6 fields names, old => new
         $this->_oldFieldsMap = array(
             'stock_status_changed_automatically' => 'stock_status_changed_auto',
             'use_config_enable_qty_increments'   => 'use_config_enable_qty_inc'

--- a/app/code/core/Mage/Sales/Model/Order.php
+++ b/app/code/core/Mage/Sales/Model/Order.php
@@ -431,7 +431,12 @@ class Mage_Sales_Model_Order extends Mage_Sales_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('order');
+        // pre 1.6 fields names, old => new
+        $this->_oldFieldsMap = [
+            'payment_authorization_expiration' => 'payment_auth_expiration',
+            'forced_do_shipment_with_invoice' => 'forced_shipment_with_invoice',
+            'base_shipping_hidden_tax_amount' => 'base_shipping_hidden_tax_amnt',
+        ];
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Creditmemo/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Creditmemo/Item.php
@@ -132,7 +132,10 @@ class Mage_Sales_Model_Order_Creditmemo_Item extends Mage_Core_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('creditmemo_item');
+        // pre 1.6 fields names, old => new
+        $this->_oldFieldsMap = [
+            'base_weee_tax_applied_row_amount' => 'base_weee_tax_applied_row_amnt',
+        ];
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/Model/Order/Invoice/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Invoice/Item.php
@@ -122,7 +122,10 @@ class Mage_Sales_Model_Order_Invoice_Item extends Mage_Core_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('invoice_item');
+        // pre 1.6 fields names, old => new
+        $this->_oldFieldsMap = [
+            'base_weee_tax_applied_row_amount' => 'base_weee_tax_applied_row_amnt',
+        ];
         return $this;
     }
     /**

--- a/app/code/core/Mage/Sales/Model/Order/Item.php
+++ b/app/code/core/Mage/Sales/Model/Order/Item.php
@@ -236,7 +236,10 @@ class Mage_Sales_Model_Order_Item extends Mage_Core_Model_Abstract
      */
     protected function _initOldFieldsMap()
     {
-        $this->_oldFieldsMap = Mage::helper('sales')->getOldFieldMap('order_item');
+        // pre 1.6 fields names, old => new
+        $this->_oldFieldsMap = [
+            'base_weee_tax_applied_row_amount' => 'base_weee_tax_applied_row_amnt',
+        ];
         return $this;
     }
 

--- a/app/code/core/Mage/Sales/etc/config.xml
+++ b/app/code/core/Mage/Sales/etc/config.xml
@@ -1198,13 +1198,6 @@
             </product>
         </catalog>
         <sales>
-            <old_fields_map>
-                <order>
-                    <payment_authorization_expiration>payment_auth_expiration</payment_authorization_expiration>
-                    <forced_do_shipment_with_invoice>forced_shipment_with_invoice</forced_do_shipment_with_invoice>
-                    <base_shipping_hidden_tax_amount>base_shipping_hidden_tax_amnt</base_shipping_hidden_tax_amount>
-                </order>
-            </old_fields_map>
             <quote>
                 <totals>
                     <nominal>

--- a/app/code/core/Mage/Weee/etc/config.xml
+++ b/app/code/core/Mage/Weee/etc/config.xml
@@ -225,17 +225,6 @@
                     </weee>
                 </totals>
             </order_creditmemo>
-            <old_fields_map>
-                <order_item>
-                    <base_weee_tax_applied_row_amount>base_weee_tax_applied_row_amnt</base_weee_tax_applied_row_amount>
-                </order_item>
-                <invoice_item>
-                    <base_weee_tax_applied_row_amount>base_weee_tax_applied_row_amnt</base_weee_tax_applied_row_amount>
-                </invoice_item>
-                <creditmemo_item>
-                    <base_weee_tax_applied_row_amount>base_weee_tax_applied_row_amnt</base_weee_tax_applied_row_amount>
-                </creditmemo_item>
-            </old_fields_map>
         </sales>
     </global>
     <adminhtml>


### PR DESCRIPTION
The mapping came with Magneto 1.6 to provide a backward compatibility
for old (pre 1.6) db field names.
Now the mapping is hardcoded in the class instead of saved
in the configuration.
This improves performance as Magento will not create tons of objects for
every new product/order/... entities.

Related: https://github.com/OpenMage/magento-lts/issues/920