### PR TITLE
Url model

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -676,7 +676,7 @@ class Mage_Catalog_Model_Url
                 $match['increment'] = $lastRequestPath;
             }
             return $match['prefix']
-                . (isset($match['increment']) ? ($match['increment'] + 1) : '1')
+                . (!empty($match['increment']) ? ((int)$match['increment'] + 1) : '1')
                 . $match['suffix'];
         }
         else {

--- a/app/code/core/Mage/Checkout/Block/Onepage/Success.php
+++ b/app/code/core/Mage/Checkout/Block/Onepage/Success.php
@@ -131,6 +131,7 @@ class Mage_Checkout_Block_Onepage_Success extends Mage_Core_Block_Template
                     'can_print_order' => $isVisible,
                     'can_view_order'  => Mage::getSingleton('customer/session')->isLoggedIn() && $isVisible,
                     'order_id'  => $order->getIncrementId(),
+                    'order' => $order,
                 ));
             }
         }
@@ -151,6 +152,7 @@ class Mage_Checkout_Block_Onepage_Success extends Mage_Core_Block_Template
                     'agreement_url' => $this->getUrl('sales/billing_agreement/view',
                         array('agreement' => $agreementId)
                     ),
+                    'agreement' => $agreement,
                 ));
             }
         }

--- a/app/code/core/Mage/Reports/Model/Totals.php
+++ b/app/code/core/Mage/Reports/Model/Totals.php
@@ -45,6 +45,9 @@ class Mage_Reports_Model_Totals
     {
         $columns = array();
         foreach ($grid->getColumns() as $col) {
+            if ($col->getTotal() === null) {
+                continue;
+            }
             $columns[$col->getIndex()] = array("total" => $col->getTotal(), "value" => 0);
         }
 

--- a/lib/Mage/HTTP/Client/Curl.php
+++ b/lib/Mage/HTTP/Client/Curl.php
@@ -345,7 +345,7 @@ implements Mage_HTTP_IClient
      * Make request
      * @param string $method
      * @param string $uri
-     * @param array $params
+     * @param array|string $params pass an array to form post, pass a json encoded string to directly post json
      * @return null
      */
     protected function makeRequest($method, $uri, $params = array())
@@ -354,7 +354,7 @@ implements Mage_HTTP_IClient
         $this->curlOption(CURLOPT_URL, $uri);
         if($method == 'POST') {
             $this->curlOption(CURLOPT_POST, 1);
-            $this->curlOption(CURLOPT_POSTFIELDS, http_build_query($params));
+            $this->curlOption(CURLOPT_POSTFIELDS, is_array($params) ? http_build_query($params) : $params);
         } elseif($method == "GET") {
             $this->curlOption(CURLOPT_HTTPGET, 1);
         } else {

--- a/lib/Varien/Io/File.php
+++ b/lib/Varien/Io/File.php
@@ -532,7 +532,8 @@ class Varien_Io_File extends Varien_Io_Abstract
     protected function _checkSrcIsFile($src)
     {
         $result = false;
-        if (is_string($src) && @is_readable($src) && is_file($src)) {
+        // both is_readable() and is_file() emit E_WARNING if there is a null byte in $src
+        if (is_string($src) && @is_readable($src) && @is_file($src)) {
             $result = true;
         }
 


### PR DESCRIPTION
Cast value to int and change isset to !empty to privent
url model to add empty string to an 1.

I've encountered the issue when I tried to reindex url rewrite from the backend, after truncating the core_url_rewrite table.

the warning is thrown only since PHP 7.1 see
https://www.php.net/manual/en/migration71.other-changes.php