### PR TITLE
Fix warning "Warning: A non-numeric value encountered" in Model_Url

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Url.php
+++ b/app/code/core/Mage/Catalog/Model/Url.php
@@ -676,7 +676,7 @@ class Mage_Catalog_Model_Url
                 $match['increment'] = $lastRequestPath;
             }
             return $match['prefix']
-                . (isset($match['increment']) ? ($match['increment'] + 1) : '1')
+                . (!empty($match['increment']) ? ((int)$match['increment'] + 1) : '1')
                 . $match['suffix'];
         }
         else {


### PR DESCRIPTION
Cast value to int and change isset to !empty to privent
url model to add empty string to an 1.